### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/rafay-circleci-orb.yml
+++ b/rafay-circleci-orb.yml
@@ -2,7 +2,11 @@
 # https://circleci.com/orbs/registry/licensing for details.
 version: 2.1
 description: |
-  Deploy a Kubernetes Cluster from CircleCI using the Rafay Systems Platform. Rafay’s turnkey SaaS platform automates the highly complex deployment and operational workflows that DevOps and SRE teams implement to operate Kubernetes clusters and Kubernetes-resident apps across clusters in cloud and data center environments. The platform accelerates organizations’ respective application modernization journeys by abstracting away the complexities of Kubernetes and other open-source container management tools. Learn more: https://rafay.co/enterprise-integrations/circleci Source: https://github.com/RafaySystems/circleci-orb
+  Deploy a Kubernetes Cluster from CircleCI using the Rafay Systems Platform. Rafay’s turnkey SaaS platform automates the highly complex deployment and operational workflows that DevOps and SRE teams implement to operate Kubernetes clusters and Kubernetes-resident apps across clusters in cloud and data center environments. The platform accelerates organizations’ respective application modernization journeys by abstracting away the complexities of Kubernetes and other open-source container management tools. Learn more: https://rafay.co/enterprise-integrations/circleci
+
+display:
+  source_url: https://github.com/RafaySystems/circleci-orb
+  home_url: https://rafay.co
 
 commands:
   init:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.